### PR TITLE
Fix "wsusi.sendNotification not a function" error after USI restart

### DIFF
--- a/views/partials/ws-usi.hbs
+++ b/views/partials/ws-usi.hbs
@@ -1,11 +1,11 @@
 <script>
-    var wsusi = new WebSocket('{{config.wsUSIEndpoint}}');
-    wsusi.onclose = function(){
+    var wsusi = {ws: new WebSocket('{{config.wsUSIEndpoint}}')};
+    wsusi.ws.onclose = function(){
         // Try to reconnect in 5 seconds
-        setTimeout(function(){wsusi = new WebSocket('{{config.wsUSIEndpoint}}')}, 2000);
+        setTimeout(function(){wsusi.ws = new WebSocket('{{config.wsUSIEndpoint}}')}, 2000);
     };
     var wsusiWaitForConnection = (callback, interval) => {
-        if (wsusi.readyState === 1) {
+        if (wsusi.ws.readyState === 1) {
             callback()
         } else {
             // optional: implement backoff for interval here
@@ -16,7 +16,7 @@
     }
     wsusi.sendNotification = function(eventType, data) {
         wsusiWaitForConnection(function() {
-            return wsusi.send(
+            return wsusi.ws.send(
                     JSON.stringify({
                         type: 'notif',
                         payload: {


### PR DESCRIPTION
Currently, `var wsusi` is a `WebSocket` object. Function `wsusi.sendNotification` is defined in `ws-usi.hbs` and called in `course_card.hbs`. Apparently, as the `wsusi` object gets re-instantiated with a `new WebSocket`,  `course_card.hbs` "looses" it and errors out with `wsusi.sendNotification is not a function` error in the browser. This stops further USI messages from being sent at normal page navigation from card to card, till the browser is reloaded. Suggested fix: change `wsusi` to a custom object with a `ws` parameter containing the WebSocket. This way, just the value of the parameter is reloaded on WS connection reset, and `course_card.hbs` continues handling the function call normally 